### PR TITLE
NN-3963: Update docker image to address vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.4-buster
+FROM node:14.17-buster-slim
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 ARG BUILD_NUMBER


### PR DESCRIPTION
Bring in line with the other docker images used by Node apps