### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.3.3
+  hmpps: ministryofjustice/hmpps@7
   browser-tools: circleci/browser-tools@1.4.1
   slack: circleci/slack@4.12.1
 
@@ -50,8 +50,7 @@ jobs:
     docker:
       - image: cimg/node:16.15.1-browsers
       - image: bitnami/redis:5.0
-        environment:
-          ALLOW_EMPTY_PASSWORD=yes
+        environment: ALLOW_EMPTY_PASSWORD=yes
     resource_class: xlarge
     steps:
       - checkout

--- a/helm_deploy/manage-key-workers/Chart.yaml
+++ b/helm_deploy/manage-key-workers/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.2.0
 
 dependencies:
   - name: generic-service
-    version: 2.6.4
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.2

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,6 +1,3 @@
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 generic-service:
   replicaCount: 2
   ingress:
@@ -22,38 +19,7 @@ generic-service:
     MANAGE_KEY_WORKERS_URL: "https://preprod.manage-key-workers.service.justice.gov.uk/"
     MAINTENANCE_MODE: false
   allowlist:
-    office: "217.33.148.210/32"
-    quantum: "62.25.109.197/32"
-    quantum_alt: "212.137.36.230/32"
-    health-kick: "35.177.252.195/32"
-    digitalprisons1: "52.56.112.98/32"
-    digitalprisons2: "52.56.118.154/32"
-    mojvpn: "81.134.202.29/32"
-    j5-phones-1: "35.177.125.252/32"
-    j5-phones-2: "35.177.137.160/32"
-    sodexo-northumberland: "88.98.48.10/32"
-    sodexo-northumberland2: "51.148.47.137/32"
-    sodoxeo-forest-bank: "51.155.85.249/32"
-    sodexo-peterborough: "51.155.55.241/32"
-    serco: "217.22.14.0/24"
-    ark-nps-hmcts-ttp1: "195.59.75.0/24"
-    ark-nps-hmcts-ttp2: "194.33.192.0/25"
-    ark-nps-hmcts-ttp3: "194.33.193.0/25"
-    ark-nps-hmcts-ttp4: "194.33.196.0/25"
-    ark-nps-hmcts-ttp5: "194.33.197.0/25"
-    oakwood-01: "217.161.76.184/29"
-    oakwood-02: "217.161.76.192/29"
-    oakwood-1: "217.161.76.187/32"
-    oakwood-2: "217.161.76.195/32"
-    oakwood-3: "217.161.76.186/32"
-    oakwood-4: "217.161.76.194/32"
-    dxc_webproxy1: "195.92.38.20/32"
-    dxc_webproxy2: "195.92.38.21/32"
-    dxc_webproxy3: "195.92.38.22/32"
-    dxc_webproxy4: "195.92.38.23/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    moj-official-tgw-prod: "51.149.250.0/24"
-    moj-official-tgw-preprod: "51.149.251.0/24"
-    global-protect: "35.176.93.186/32"
+    groups:
+      - internal
+      - prisons
+      - private_prisons

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -1,6 +1,3 @@
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 generic-service:
   replicaCount: 4
   env:
@@ -22,57 +19,10 @@ generic-service:
   ingress:
     host: manage-key-workers.service.justice.gov.uk
   allowlist:
-    office: "217.33.148.210/32"
-    quantum: "62.25.109.197/32"
-    quantum_alt: "212.137.36.230/32"
-    health-kick: "35.177.252.195/32"
-    digitalprisons1: "52.56.112.98/32"
-    digitalprisons2: "52.56.118.154/32"
-    mojvpn: "81.134.202.29/32"
-    j5-phones-1: "35.177.125.252/32"
-    j5-phones-2: "35.177.137.160/32"
-    sodexo-northumberland: "88.98.48.10/32"
-    sodexo-northumberland2: "51.148.47.137/32"
-    sodoxeo-forest-bank: "51.155.85.249/32"
-    sodexo-peterborough: "51.155.55.241/32"
-    sodexo2: "51.148.9.201"
-    serco: "217.22.14.0/24"
-    ark-nps-hmcts-ttp1: "195.59.75.0/24"
-    ark-nps-hmcts-ttp2: "194.33.192.0/25"
-    ark-nps-hmcts-ttp3: "194.33.193.0/25"
-    ark-nps-hmcts-ttp4: "194.33.196.0/25"
-    ark-nps-hmcts-ttp5: "194.33.197.0/25"
-    oakwood-01: "217.161.76.184/29"
-    oakwood-02: "217.161.76.192/29"
-    oakwood-1: "217.161.76.187/32"
-    oakwood-2: "217.161.76.195/32"
-    oakwood-3: "217.161.76.186/32"
-    oakwood-4: "217.161.76.194/32"
-    dxc_webproxy1: "195.92.38.20/32"
-    dxc_webproxy2: "195.92.38.21/32"
-    dxc_webproxy3: "195.92.38.22/32"
-    dxc_webproxy4: "195.92.38.23/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    moj-official-tgw-prod: "51.149.250.0/24"
-    moj-official-tgw-preprod: "51.149.251.0/24"
-    moj-official-ark-c-expo-e: "51.149.249.0/29"
-    moj-official-ark-c-vodafone: "194.33.248.0/29"
-    moj-official-ark-f-vodafone: "194.33.249.0/29"
-    moj-official-ark-f-expo-e: "51.149.249.32/29"
-    fivewells-1: "20.49.214.199/32"
-    fivewells-2: "20.49.214.228/32"
-    fivewells-3: "195.89.157.56/29"
-    fivewells-4: "195.59.215.184/29"
-    fivewells-5: "51.149.250.0/24"
-    fivewells-6: "51.149.249.0/29"
-    fivewells-7: "194.33.249.0/29"
-    fivewells-8: "51.149.249.32/29"
-    fivewells-9: "194.33.248.0/29"
-    global-protect: "35.176.93.186/32"
-    azure-landing-zone-public-egress-1: "20.26.11.71/32"
-    azure-landing-zone-public-egress-2: "20.26.11.108/32"
+    groups:
+      - internal
+      - prisons
+      - private_prisons
 
 # determine which slack channel alerts are sent to, via the correct Alert Manager receiver
 generic-prometheus-alerts:


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

2 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/values-preprod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons,private_prisons`
- The size of the allowlist defined in this file will change: `35 => 0 (35 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- petty-france-wifi
  

- moj-official-ark-c-expo-e
  

- moj-official-ark-c-vodafone
  

- moj-official-ark-f-vodafone
  

- moj-official-ark-f-expo-e
  

- mojo-azure-landing-zone-public-egress-1
  

- mojo-azure-landing-zone-public-egress-2
  

- mojo-azure-landing-zone-public-egress-3
  

- mojo-azure-landing-zone-public-egress-4
  

- sodexo1
  

- sodexo2
  

- sodexo3
  

- sodexo4
  

- fivewells-3
  

- fivewells-4
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- quantum
  

- quantum_alt
  

- health-kick
  

- digitalprisons1
  

- digitalprisons2
  

- j5-phones-1
  

- j5-phones-2
  

- dxc_webproxy1
  

- dxc_webproxy2
  

- dxc_webproxy3
  

- dxc_webprox23
  

## Allowlist: helm_deploy/values-prod.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons,private_prisons`
- The size of the allowlist defined in this file will change: `46 => 0 (46 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- petty-france-wifi
  

- sodexo1
  

- sodexo2
  

- sodexo3
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- quantum
  

- quantum_alt
  

- health-kick
  

- digitalprisons1
  

- digitalprisons2
  

- j5-phones-1
  

- j5-phones-2
  

- dxc_webproxy1
  

- dxc_webproxy2
  

- dxc_webproxy3
  

- dxc_webprox23
  
