### PR TITLE
Add middleware and env var for switch-off

### DIFF
--- a/backend/middleware/redirectToNewService.js
+++ b/backend/middleware/redirectToNewService.js
@@ -1,0 +1,10 @@
+const REDIRECT_ENABLED_PRISONS = process.env.REDIRECT_ENABLED_PRISONS ?? ''
+
+module.exports = () => (req, res, next) => {
+  const activeCaseLoadId = req.session?.userDetails?.activeCaseLoadId
+  if (activeCaseLoadId && REDIRECT_ENABLED_PRISONS.includes(activeCaseLoadId)) {
+    res.redirect(`${process.env.ALLOCATIONS_UI_URL}/key-worker`)
+  } else {
+    next()
+  }
+}

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -26,6 +26,8 @@ const manageKeyWorkerSettings = require('./controllers/manageKeyWorkerSettings')
 
 const systemOauthClient = require('./api/systemOauthClient')
 
+const redirectToNewService = require('./middleware/redirectToNewService')
+
 const configureRoutes = ({ hmppsManageUsersApi, elite2Api, prisonerSearchApi, keyworkerApi, complexityOfNeedApi }) => {
   const router = express.Router()
   const allocationService = allocationServiceFactory(
@@ -35,6 +37,7 @@ const configureRoutes = ({ hmppsManageUsersApi, elite2Api, prisonerSearchApi, ke
     config.app.offenderSearchResultMax,
     systemOauthClient
   )
+  router.get('*', redirectToNewService())
 
   const controller = controllerFactory(allocationService, keyworkerPrisonStatsFactory(keyworkerApi))
   router.use('/api/config', getConfiguration)

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -21,6 +21,7 @@ generic-service:
     HMPPS_COOKIE_DOMAIN: dev.manage-key-workers.service.justice.gov.uk
     MANAGE_KEY_WORKERS_URL: "https://dev.manage-key-workers.service.justice.gov.uk/"
     ALLOCATIONS_UI_URL: "https://allocate-key-workers-dev.hmpps.service.justice.gov.uk"
+    REDIRECT_ENABLED_PRISONS: "MDI"
     MAINTENANCE_MODE: false
     ENVIRONMENT_NAME: DEV
   allowlist:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -18,6 +18,7 @@ generic-service:
     HMPPS_COOKIE_DOMAIN: preprod.manage-key-workers.service.justice.gov.uk
     MANAGE_KEY_WORKERS_URL: "https://preprod.manage-key-workers.service.justice.gov.uk/"
     ALLOCATIONS_UI_URL: "https://allocate-key-workers-preprod.hmpps.service.justice.gov.uk"
+    REDIRECT_ENABLED_PRISONS: ""
     MAINTENANCE_MODE: false
     ENVIRONMENT_NAME: PRE-PRODUCTION
   allowlist:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -15,6 +15,7 @@ generic-service:
     PRISONS_WITH_OFFENDERS_THAT_HAVE_COMPLEX_NEEDS: "AGI,BZI,DHI,DWI,ESI,EWI,FHI,LNI,NHI,PFI,SDI,STI"
     MANAGE_KEY_WORKERS_URL: "https://manage-key-workers.service.justice.gov.uk/"
     ALLOCATIONS_UI_URL: "https://allocate-key-workers.hmpps.service.justice.gov.uk"
+    REDIRECT_ENABLED_PRISONS: ""
     HMPPS_COOKIE_DOMAIN: manage-key-workers.service.justice.gov.uk
     MAINTENANCE_MODE: false
     ENVIRONMENT_NAME: PRODUCTION


### PR DESCRIPTION
This PR adds a new env var `REDIRECT_ENABLED_PRISONS` to the helm files and corresponding middleware to redirect user to the new service.
This is set only for MDI (Moorland) on dev so that it can be tested first.